### PR TITLE
Use a packaged zip binary instead of system zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Building
 - busybox:
 	- src: https://github.com/linusyang/android-busybox-ndk
 	- bin: https://code.google.com/p/yangapp/downloads/detail?name=busybox-1.21.1
+- zip:
+	- src: https://github.com/jruesga/android_external_zip
 - smali/baksmali: 
 	- src: https://bitbucket.org/JesusFreke/smali/src
 	- bin: https://bitbucket.org/JesusFreke/smali/downloads
@@ -51,5 +53,5 @@ Building
 	calling	`dx --dex --output=file-dvk.jar file.jar`	for each of those files
 2.	Create a flashable zip file using using the given updater-script
 3.	In the newly created zip file, create a folder freecyngn on /
-4.	Copy busybox binary, the three *-dvk.jar files and the *.sh files in the zips subfolder
+4.	Copy busybox binary, zip binary, the three *-dvk.jar files and the *.sh files in the zips subfolder
 5.	You're done

--- a/freecyngn.sh
+++ b/freecyngn.sh
@@ -71,7 +71,7 @@ dalvikvm -Xmx256m -cp $BASE_DIR/smali-dvk.jar org.jf.smali.main  -o $TMP_DIR/Set
 
 echo "Adding new classes.dex to Settings.apk..." >> $LOGFILE
 cd $TMP_DIR/Settings
-echo classes.dex | zip -0 -@ $SETTINGS_APP >> $LOGFILE
+echo classes.dex | $BASE_DIR/zip -0 -@ $SETTINGS_APP >> $LOGFILE
 
 echo "Cleaning up apps..." >> $LOGFILE
 rm /system/*app/CMAccount.apk

--- a/updater-script
+++ b/updater-script
@@ -5,6 +5,7 @@ ui_print("Extracting package...");
 run_program("/sbin/busybox", "mkdir", "/system/freecyngn");
 package_extract_dir("freecyngn", "/system/freecyngn");
 set_perm(0,0,0755,"/system/freecyngn/busybox");
+set_perm(0,0,0755,"/system/freecyngn/zip");
 set_perm(0,0,0755,"/system/freecyngn/freecyngn.sh");
 
 ui_print("Cleaning up [this will take a while] ...");


### PR DESCRIPTION
As some roms do not provide a zip tool (https://github.com/mar-v-in/freecyngn/issues/2), freecyngn should use its own zip binary.

Info-Zip is open source and can be compiled by oneself. There is a GitHub repository with a patch to get zip running on Android here: https://github.com/jruesga/android_external_zip
